### PR TITLE
修复设置 Cursor 设置无效

### DIFF
--- a/src/AntdUI/Controls/Breadcrumb.cs
+++ b/src/AntdUI/Controls/Breadcrumb.cs
@@ -35,6 +35,11 @@ namespace AntdUI
     [DefaultEvent("ItemClick")]
     public class Breadcrumb : IControl
     {
+        public Breadcrumb()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         int gap = 12;

--- a/src/AntdUI/Controls/Button.cs
+++ b/src/AntdUI/Controls/Button.cs
@@ -41,6 +41,7 @@ namespace AntdUI
             SetStyle(ControlStyles.StandardClick | ControlStyles.StandardDoubleClick, false);
             base.BackColor = Color.Transparent;
             button = new IButton(this, () => BeforeAutoSize());
+            Cursor = Cursors.Hand;
         }
 
         #region 属性

--- a/src/AntdUI/Controls/Calendar.cs
+++ b/src/AntdUI/Controls/Calendar.cs
@@ -45,6 +45,7 @@ namespace AntdUI
             hover_month = new ITaskOpacity(this);
             hover_button = new ITaskOpacity(this);
             Date = DateNow;
+            Cursor = Cursors.Hand;
         }
 
         #region 属性

--- a/src/AntdUI/Controls/Carousel.cs
+++ b/src/AntdUI/Controls/Carousel.cs
@@ -36,6 +36,11 @@ namespace AntdUI
     [Designer(typeof(IControlDesigner))]
     public class Carousel : IControl
     {
+        public Carousel()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         /// <summary>

--- a/src/AntdUI/Controls/Chat/ChatList.cs
+++ b/src/AntdUI/Controls/Chat/ChatList.cs
@@ -275,7 +275,11 @@ namespace AntdUI.Chat
 
         }
 
-        public ChatList() { ScrollBar = new ScrollBar(this); }
+        public ChatList()
+        {
+            ScrollBar = new ScrollBar(this);
+            Cursor = Cursors.Hand;
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/src/AntdUI/Controls/Chat/MsgList.cs
+++ b/src/AntdUI/Controls/Chat/MsgList.cs
@@ -162,7 +162,11 @@ namespace AntdUI.Chat
             }
         }
 
-        public MsgList() { ScrollBar = new ScrollBar(this); }
+        public MsgList()
+        {
+            ScrollBar = new ScrollBar(this);
+            Cursor = Cursors.Hand;
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/src/AntdUI/Controls/Checkbox.cs
+++ b/src/AntdUI/Controls/Checkbox.cs
@@ -34,6 +34,11 @@ namespace AntdUI
     [DefaultEvent("CheckedChanged")]
     public class Checkbox : IControl
     {
+        public Checkbox()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         Color? fore;

--- a/src/AntdUI/Controls/IControl.cs
+++ b/src/AntdUI/Controls/IControl.cs
@@ -116,6 +116,14 @@ namespace AntdUI
 
         #endregion
 
+        private Cursor _cursor;
+
+        public override Cursor Cursor
+        {
+            get => base.Cursor;
+            set => base.Cursor = _cursor = value;
+        }
+
         #endregion
 
         /// <summary>
@@ -185,7 +193,6 @@ namespace AntdUI
             OnSizeChanged(EventArgs.Empty);
         }
 
-
         internal void SetCursor(bool val)
         {
             if (InvokeRequired)
@@ -196,7 +203,8 @@ namespace AntdUI
                 }));
                 return;
             }
-            Cursor = val ? Cursors.Hand : DefaultCursor;
+
+            base.Cursor = val ? _cursor : DefaultCursor;
         }
 
         #region 渲染文本

--- a/src/AntdUI/Controls/InputNumber.cs
+++ b/src/AntdUI/Controls/InputNumber.cs
@@ -201,6 +201,7 @@ namespace AntdUI
             hover_button = new ITaskOpacity(this);
             hover_button_up = new ITaskOpacity(this);
             hover_button_bottom = new ITaskOpacity(this);
+            Cursor = Cursors.Hand;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/AntdUI/Controls/Layout/VirtualPanel.cs
+++ b/src/AntdUI/Controls/Layout/VirtualPanel.cs
@@ -40,6 +40,7 @@ namespace AntdUI
         public VirtualPanel()
         {
             ScrollBar = new ScrollBar(this);
+            Cursor = Cursors.Hand;
             new Thread(LongTask)
             {
                 IsBackground = true

--- a/src/AntdUI/Controls/Menu.cs
+++ b/src/AntdUI/Controls/Menu.cs
@@ -480,7 +480,11 @@ namespace AntdUI
 
         #region 渲染
 
-        public Menu() { ScrollBar = new ScrollBar(this); }
+        public Menu()
+        {
+            ScrollBar = new ScrollBar(this);
+            Cursor = Cursors.Hand;
+        }
         protected override void OnPaint(PaintEventArgs e)
         {
             if (items == null || items.Count == 0) return;

--- a/src/AntdUI/Controls/Pagination.cs
+++ b/src/AntdUI/Controls/Pagination.cs
@@ -35,6 +35,11 @@ namespace AntdUI
     [DefaultEvent("ValueChanged")]
     public class Pagination : IControl
     {
+        public Pagination()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         int current = 1;

--- a/src/AntdUI/Controls/Radio.cs
+++ b/src/AntdUI/Controls/Radio.cs
@@ -35,6 +35,11 @@ namespace AntdUI
     [DefaultEvent("CheckedChanged")]
     public class Radio : IControl
     {
+        public Radio()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         Color? fore;

--- a/src/AntdUI/Controls/Segmented.cs
+++ b/src/AntdUI/Controls/Segmented.cs
@@ -37,6 +37,7 @@ namespace AntdUI
         public Segmented()
         {
             base.BackColor = Color.Transparent;
+            Cursor = Cursors.Hand;
         }
 
         #region 属性

--- a/src/AntdUI/Controls/Slider.cs
+++ b/src/AntdUI/Controls/Slider.cs
@@ -35,6 +35,11 @@ namespace AntdUI
     [DefaultEvent("ValueChanged")]
     public class Slider : IControl
     {
+        public Slider()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         Color? fill;

--- a/src/AntdUI/Controls/Steps.cs
+++ b/src/AntdUI/Controls/Steps.cs
@@ -35,6 +35,11 @@ namespace AntdUI
     [DefaultEvent("ItemClick")]
     public class Steps : IControl
     {
+        public Steps()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         Color? fore;

--- a/src/AntdUI/Controls/Switch.cs
+++ b/src/AntdUI/Controls/Switch.cs
@@ -35,6 +35,11 @@ namespace AntdUI
     [DefaultEvent("CheckedChanged")]
     public class Switch : IControl
     {
+        public Switch()
+        {
+            Cursor = Cursors.Hand;
+        }
+
         #region 属性
 
         Color? fore;

--- a/src/AntdUI/Controls/Table/Table.cs
+++ b/src/AntdUI/Controls/Table/Table.cs
@@ -466,7 +466,11 @@ namespace AntdUI
 
         #region 初始化
 
-        public Table() { ScrollBar = new ScrollBar(this, true, true, radius, !visibleHeader); }
+        public Table()
+        {
+            ScrollBar = new ScrollBar(this, true, true, radius, !visibleHeader);
+            Cursor = Cursors.Hand;
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/src/AntdUI/Controls/Tag.cs
+++ b/src/AntdUI/Controls/Tag.cs
@@ -535,6 +535,7 @@ namespace AntdUI
         {
             base.BackColor = Color.Transparent;
             hover_close = new ITaskOpacity(this);
+            Cursor = Cursors.Hand;
         }
 
         RectangleF rect_close;

--- a/src/AntdUI/Controls/Timeline.cs
+++ b/src/AntdUI/Controls/Timeline.cs
@@ -175,7 +175,11 @@ namespace AntdUI
 
         #region 渲染
 
-        public Timeline() { ScrollBar = new ScrollBar(this); }
+        public Timeline()
+        {
+            ScrollBar = new ScrollBar(this);
+            Cursor = Cursors.Hand;
+        }
 
         readonly StringFormat stringFormatLeft = Helper.SF(lr: StringAlignment.Near);
 

--- a/src/AntdUI/Controls/Tree.cs
+++ b/src/AntdUI/Controls/Tree.cs
@@ -462,6 +462,7 @@ namespace AntdUI
         public Tree()
         {
             ScrollBar = new ScrollBar(this, true, true);
+            Cursor = Cursors.Hand;
         }
 
         protected override void OnPaint(PaintEventArgs e)


### PR DESCRIPTION
修复设置 Cursor 设置无效，由于Winform默认Cursor都是Default设计器的默认值无法更改，而控件大多都默认了Hand，为了不影响原有所以在构造函数加了Cursor = Cursors.Hand，但会导致如果想设置成Arrow只能通过代码设置，还是建议交给用户设置这样就能与设计器同步，可以考虑下是否合并或者其它解决方案