### PR TITLE
修复: ILayeredFormAnimate 在 Dispose 时可能引发的字典访问异常

### DIFF
--- a/src/AntdUI/Forms/LayeredWindow/ILayeredFormAnimate.cs
+++ b/src/AntdUI/Forms/LayeredWindow/ILayeredFormAnimate.cs
@@ -378,7 +378,11 @@ namespace AntdUI
         protected override void Dispose(bool disposing)
         {
             task_start?.Dispose();
-            list[key].Remove(this);
+            if (list.TryGetValue(key, out var layeredFormAnimateList) && layeredFormAnimateList.Contains(this))
+            {
+                if (layeredFormAnimateList.Count == 1) list.Remove(key);
+                else layeredFormAnimateList.Remove(this);
+            }
             base.Dispose(disposing);
         }
     }
@@ -527,31 +531,31 @@ namespace AntdUI
         {
             try
             {
+                if (!ILayeredFormAnimate.list.TryGetValue(key, out var list) || list.Count == 0) return;
                 switch (align)
                 {
                     case TAlignFrom.Bottom:
                     case TAlignFrom.BL:
                     case TAlignFrom.BR:
-                        CloseB(key, name);
+                        CloseB(key, name, list);
                         break;
                     case TAlignFrom.Top:
                     case TAlignFrom.TL:
                     case TAlignFrom.TR:
                     default:
-                        CloseT(key, name);
+                        CloseT(key, name, list);
                         break;
                 }
             }
             catch { }
         }
 
-        static void CloseT(string key, string name)
+        static void CloseT(string key, string name, List<ILayeredFormAnimate> list)
         {
             var arr = key.Split('|');
             int y = int.Parse(arr[2]);
             int offset = (int)(Config.NoticeWindowOffsetXY * Config.Dpi);
             int y_temp = y + offset;
-            var list = ILayeredFormAnimate.list[key];
             var dir = new Dictionary<ILayeredFormAnimate, int[]>(list.Count);
             foreach (var it in list)
             {
@@ -596,13 +600,12 @@ namespace AntdUI
                 }
             }
         }
-        static void CloseB(string key, string name)
+        static void CloseB(string key, string name, List<ILayeredFormAnimate> list)
         {
             var arr = key.Split('|');
             int b = int.Parse(arr[4]);
             int offset = (int)(Config.NoticeWindowOffsetXY * Config.Dpi);
             int y_temp = b - offset;
-            var list = ILayeredFormAnimate.list[key];
             var dir = new Dictionary<ILayeredFormAnimate, int[]>(list.Count);
             foreach (var it in list)
             {


### PR DESCRIPTION
## 问题描述

在窗口最小化时显示 Message 消息，当 GC 触发调用 ILayeredFormAnimate 对象的 Dispose 方法时，
可能会发生 KeyNotFoundException 异常导致程序崩溃。

## 问题复现
新建一个Winform项目,在一个窗体内添加一个按钮并添加以下代码。当GC触发并执行到
ILayeredFormAnimate.Dispose时,程序将会崩溃。
```csharp
using AntdUI;
using Message = AntdUI.Message;

namespace AntdUITest;
public partial class FormMain : Window
{
    public FormMain()
    {
        Config.ShowInWindow = true;
        this.InitializeComponent();
        this.button1.Click += this.button1_Click;
    }

    private async void button1_Click(object? sender, EventArgs e)
    {
        Message.info(this, "测试开始。将在3秒后显示一个Message然后进行强制GC。请最小化窗口。");
        await Task.Delay(2000);
        this.WindowState = FormWindowState.Minimized; // 最小化窗口
        await Task.Delay(1000);
        Message.info(this, "一条message测试信息");
        Task.Delay(2000).ContinueWith(_ =>
        {
            TriggerGc();
        });
    }

    /// <summary>
    /// 强制触发GC
    /// </summary>
    public static void TriggerGc()
    {
        Console.WriteLine("强制触发GC...");
        GC.Collect(2, GCCollectionMode.Forced, true, true);
        GC.WaitForPendingFinalizers();
        GC.Collect(2, GCCollectionMode.Forced, true, true);
    }
}
```


## 修复方法

1. 在 ILayeredFormAnimate.Dispose 中添加了对字典的安全检查
2. 在 MsgQueue.Close 方法中添加了对目标列表存在性的检查，同时将获取的列表直接传递给CloseT/CloseB方法