### PR TITLE
feat(InputNumber): add ValueFormatter option

### DIFF
--- a/example/Demo/Controls/InputNumber.Designer.cs
+++ b/example/Demo/Controls/InputNumber.Designer.cs
@@ -56,6 +56,8 @@ namespace Demo.Controls
             panel1 = new System.Windows.Forms.Panel();
             panel2 = new System.Windows.Forms.Panel();
             divider1 = new AntdUI.Divider();
+            inputNumberWithValueFormatter = new AntdUI.InputNumber();
+            inputNumberWithoutValueFormatter = new AntdUI.InputNumber();
             panel1.SuspendLayout();
             panel2.SuspendLayout();
             SuspendLayout();
@@ -154,6 +156,8 @@ namespace Demo.Controls
             // 
             panel2.Controls.Add(input6);
             panel2.Controls.Add(input5);
+            panel2.Controls.Add(inputNumberWithoutValueFormatter);
+            panel2.Controls.Add(inputNumberWithValueFormatter);
             panel2.Controls.Add(input4);
             panel2.Controls.Add(input2);
             panel2.Controls.Add(input3);
@@ -161,7 +165,7 @@ namespace Demo.Controls
             panel2.Dock = DockStyle.Top;
             panel2.Location = new Point(0, 28);
             panel2.Name = "panel2";
-            panel2.Size = new Size(555, 162);
+            panel2.Size = new Size(555, 214);
             panel2.TabIndex = 0;
             // 
             // divider1
@@ -176,6 +180,32 @@ namespace Demo.Controls
             divider1.TabIndex = 1;
             divider1.TabStop = false;
             divider1.Text = "常规";
+            // 
+            // inputNumberWithValueFormatter
+            // 
+            inputNumberWithValueFormatter.DecimalPlaces = 2;
+            inputNumberWithValueFormatter.Increment = new decimal(new int[] { 1000, 0, 0, 0 });
+            inputNumberWithValueFormatter.Location = new Point(244, 152);
+            inputNumberWithValueFormatter.Name = "inputNumberWithValueFormatter";
+            inputNumberWithValueFormatter.Radius = 0;
+            inputNumberWithValueFormatter.Size = new Size(220, 44);
+            inputNumberWithValueFormatter.TabIndex = 3;
+            inputNumberWithValueFormatter.Text = "10,000.00";
+            inputNumberWithValueFormatter.ThousandsSeparator = true;
+            inputNumberWithValueFormatter.Value = new decimal(new int[] { 10000, 0, 0, 0 });
+            // 
+            // inputNumberWithoutValueFormatter
+            // 
+            inputNumberWithoutValueFormatter.DecimalPlaces = 2;
+            inputNumberWithoutValueFormatter.Increment = new decimal(new int[] { 1000, 0, 0, 0 });
+            inputNumberWithoutValueFormatter.Location = new Point(18, 152);
+            inputNumberWithoutValueFormatter.Name = "inputNumberWithoutValueFormatter";
+            inputNumberWithoutValueFormatter.Radius = 0;
+            inputNumberWithoutValueFormatter.Size = new Size(220, 44);
+            inputNumberWithoutValueFormatter.TabIndex = 3;
+            inputNumberWithoutValueFormatter.Text = "10,000.00";
+            inputNumberWithoutValueFormatter.ThousandsSeparator = true;
+            inputNumberWithoutValueFormatter.Value = new decimal(new int[] { 10000, 0, 0, 0 });
             // 
             // InputNumber
             // 
@@ -201,5 +231,7 @@ namespace Demo.Controls
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Panel panel2;
         private AntdUI.Divider divider1;
+        private AntdUI.InputNumber inputNumberWithValueFormatter;
+        private AntdUI.InputNumber inputNumberWithoutValueFormatter;
     }
 }

--- a/example/Demo/Controls/InputNumber.cs
+++ b/example/Demo/Controls/InputNumber.cs
@@ -17,6 +17,7 @@
 // CSDN: https://blog.csdn.net/v_132
 // QQ: 17379620
 
+using System.Globalization;
 using System.Windows.Forms;
 
 namespace Demo.Controls
@@ -28,6 +29,17 @@ namespace Demo.Controls
         {
             form = _form;
             InitializeComponent();
+            inputNumberWithValueFormatter.ValueFormatter = (value) =>
+            {
+                if (value % 1 == 0)
+                {
+                    return ((int)value).ToString("N0");
+                }
+                else
+                {
+                    return value.ToString($"N{inputNumberWithValueFormatter.DecimalPlaces}", CultureInfo.CurrentCulture);
+                }
+            };
         }
     }
 }

--- a/src/AntdUI/Controls/InputNumber.cs
+++ b/src/AntdUI/Controls/InputNumber.cs
@@ -181,9 +181,27 @@ namespace AntdUI
         [Description("当按下箭头键时，是否持续增加/减少"), Category("行为"), DefaultValue(true)]
         public bool InterceptArrowKeys { get; set; } = true;
 
+        Func<decimal, string>? valueFormatter;
+        /// <summary>
+        /// Gets or sets a custom function to format the numeric value for display
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Func<decimal, string>? ValueFormatter
+        {
+            get => valueFormatter;
+            set
+            {
+                if (valueFormatter == value) return;
+                valueFormatter = value;
+                Text = GetNumberText(currentValue);
+            }
+        }
+
         string GetNumberText(decimal num)
         {
             if (Hexadecimal) return ((long)num).ToString("X", CultureInfo.InvariantCulture);
+            if (ValueFormatter != null) try { return ValueFormatter(num); } catch { }
             return num.ToString((ThousandsSeparator ? "N" : "F") + DecimalPlaces.ToString(CultureInfo.CurrentCulture), CultureInfo.CurrentCulture);
         }
 


### PR DESCRIPTION
Added a new `ValueFormatter` property to `InputNumber` so numbers can be shown with custom formatting. If no formatter is set, or throws an exception, it still uses the normal `DecimalPlaces` and `ThousandsSeparator` rules.

Also updated the Demo to show two examples: one with the default formatting (always shows decimals) and one with a `ValueFormatter` (integers without decimals, decimals with precision).

closes #92 